### PR TITLE
feat: add Codex compatibility

### DIFF
--- a/.agents/skills/audio-plugin-coder/SKILL.md
+++ b/.agents/skills/audio-plugin-coder/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: audio-plugin-coder
+description: Run Audio Plugin Coder lifecycle actions for JUCE plugins, including dream, plan, design, implement, test, debug, status, resume, and ship. Use when the user asks to create or continue an APC audio plugin or mentions an APC phase.
+---
+
+Load and follow `../../../skills/audio-plugin-coder/SKILL.md`, resolving the path relative to this file. This repository-scoped loader makes the packaged APC skill available without installing the Codex plugin.

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,39 @@
+{
+  "name": "audio-plugin-coder",
+  "version": "0.3.0",
+  "description": "Build JUCE audio plugins with APC's phase-gated workflow.",
+  "author": {
+    "name": "Noizefield",
+    "url": "https://github.com/Noizefield"
+  },
+  "homepage": "https://github.com/Noizefield/audio-plugin-coder",
+  "repository": "https://github.com/Noizefield/audio-plugin-coder",
+  "license": "MIT",
+  "keywords": [
+    "audio",
+    "juce",
+    "vst3",
+    "audio-plugin",
+    "dsp"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Audio Plugin Coder",
+    "shortDescription": "Build JUCE plugins with a gated AI workflow",
+    "longDescription": "Guide JUCE audio plugins from concept through architecture, UI, implementation, testing, and packaging.",
+    "developerName": "Noizefield",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Interactive",
+      "Write",
+      "Shell"
+    ],
+    "websiteURL": "https://github.com/Noizefield/audio-plugin-coder",
+    "defaultPrompt": [
+      "Dream a new audio plugin with Audio Plugin Coder.",
+      "Resume my current APC plugin from its saved phase.",
+      "Check the status of my APC audio plugin."
+    ],
+    "brandColor": "#0078D4"
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# Audio Plugin Coder — Agent Guidance
+
+## Scope
+
+These instructions apply to the entire repository and are written for any coding agent that reads the `AGENTS.md` standard (Codex, Cursor, and others). Agents with their own APC configuration (Claude Code via `.claude/`, Kilo via `.kilocode/`) should treat that configuration as primary; this file stays consistent with it.
+
+## APC Workflow
+
+- Use the `audio-plugin-coder` skill for APC lifecycle work.
+- APC commands such as `/dream`, `/design`, and `/impl` in the documentation are Claude Code/Kilo slash-command syntax. If your agent does not define them, use the `audio-plugin-coder` skill or an equivalent natural-language request instead.
+
+## Codex
+
+- Invoke APC as `$audio-plugin-coder:audio-plugin-coder <action> <PluginName>` or use an equivalent natural-language request.
+- Never use Codex `/plan` or `/status` as APC workflow commands; those names are reserved by Codex built-ins.
+- See `docs/codex-compatibility.md` for setup and the full command mapping.
+
+## Required Context
+
+- Before changing `plugins/<PluginName>/`, read its `status.json`.
+- Read the relevant workflow and skill under `.claude/`; fall back to the matching `.agent/` file if needed.
+- Also read `.claude/rules/juce-build-protocols.md` and `.claude/rules/file-naming-conventions.md` before implementation, build, or packaging work.
+- Preserve the selected `ui_framework`: Visage work must not introduce WebView files, and WebView work must not introduce Visage controls.
+
+## Platform Rules
+
+- Detect the host OS before choosing commands.
+- Use PowerShell and `.ps1` scripts on Windows.
+- Use Bash/Zsh and `.sh` scripts on macOS or Linux.
+- Do not copy a PowerShell example from an APC workflow verbatim on macOS or Linux; use the equivalent shell function or script.
+
+## Phase Gates
+
+- Complete only the requested APC phase.
+- Validate the prior phase before writing files.
+- Back up plugin state before implementation, debugging, or packaging changes.
+- Update `status.json` through the platform state-management script when a phase completes.
+- Stop after the requested phase instead of automatically starting the next phase.
+
+## Build and Validation
+
+- Run build operations from the repository root.
+- Do not invoke raw `cmake`, `xcodebuild`, `msbuild`, or compiler commands for normal APC builds.
+- Use `scripts/build-and-install.ps1` on Windows or `scripts/build-and-install.sh` on macOS/Linux.
+- Start with the narrowest validation relevant to the changed plugin.
+- Do not alter unrelated generated plugins, build artifacts, or user debug output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Codex compatibility**
+  - Added repository-wide `AGENTS.md` guidance.
+  - Added a repo-discoverable and packageable `audio-plugin-coder` skill.
+  - Added a `.codex-plugin/plugin.json` plugin manifest.
+  - Documented Codex command mappings for APC slash-command collisions.
+
 ---
 
 ## [0.3.0] - 2026-03-23

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Over the past 18 months, APC has been continuously designed, tested, and re-iter
 
 **Midway through development, I stumbled upon the excellent work of [TÂCHES (glittercowboy)](https://github.com/glittercowboy).** His approach to context engineering was a revelation. I adopted some of his core ideas, particularly regarding meta prompting and structured agent workflows and integrated them directly into APC's DNA to create a more robust system.
 
-APC is designed to be **Agent Agnostic**. Whether you use Google's Antigravity, Kilo, Claude Code, or Cursor, APC provides the structure they need to succeed.
+APC is designed to be **Agent Agnostic**. Whether you use Codex, Google's Antigravity, Kilo, Claude Code, or Cursor, APC provides the structure they need to succeed.
 
 ## ⚠️ Development Status Disclaimer
 
@@ -36,7 +36,7 @@ Instead of manually juggling DSP architecture, UI frameworks, build systems, sta
 
 ## ✨ Key Features
 
-- 🤖 **LLM-Driven Development** - Designed to work with Antigravity, Kilo, Claude Code, Cursor, or any coding agent.
+- 🤖 **LLM-Driven Development** - Designed to work with Codex, Antigravity, Kilo, Claude Code, Cursor, or any coding agent.
 - 🎯 **Structured Workflows** - Five-phase system: Dream → Plan → Design → Implement → Ship.
 - 🎨 **Dual UI Frameworks** - Choose Visage (pure C++) or WebView (HTML5 Canvas).
 - 📊 **State Management** - Automatic progress tracking, validation, and rollback capabilities.
@@ -86,7 +86,7 @@ bash scripts/system-check.sh   # verify your environment
 
 **Linux:** CMake 3.22+, GCC/Clang, Git
 
-**All platforms:** An LLM coding agent (Claude Code, Antigravity, Kilo, Cursor)
+**All platforms:** An LLM coding agent (Codex, Claude Code, Antigravity, Kilo, Cursor)
 
 ### Bridge Templates (FFGL & Max/MSP)
 
@@ -114,7 +114,13 @@ For **Claude Code**:
 # The agent will discover workflows from .agent/workflows/
 ```
 
-3. **Create your first plugin:**
+For **Codex**:
+```text
+# AGENTS.md and the repo-local skill are discovered automatically
+$audio-plugin-coder:audio-plugin-coder dream MyReverb
+```
+
+3. **Create your first plugin in Claude Code or Kilo:**
 ```
 /dream MyReverb
 ```
@@ -142,18 +148,22 @@ The AI will guide you through the entire process!
    ↓ Build installers, test in DAWs
 ```
 
-### Slash Commands
+### Agent Commands
 
-| Command | Description |
-|---------|-------------|
-| `/dream [Name]` | Start new plugin with ideation phase |
-| `/plan [Name]` | Define architecture and select UI framework |
-| `/design [Name]` | Create GUI mockups and visual design |
-| `/impl [Name]` | Implement DSP and UI code |
-| `/ship [Name]` | Package and distribute plugin |
-| `/status [Name]` | Check current progress and state |
-| `/resume [Name]` | Continue development from last phase |
-| `/new [Name]` | Run complete workflow with confirmations |
+Claude Code and Kilo use APC's slash commands. Codex uses the `audio-plugin-coder` skill because `/plan` and `/status` are built-in Codex commands.
+
+| Claude Code / Kilo | Codex | Description |
+|---------|-------------|-------------|
+| `/dream [Name]` | `$audio-plugin-coder:audio-plugin-coder dream [Name]` | Start new plugin with ideation phase |
+| `/plan [Name]` | `$audio-plugin-coder:audio-plugin-coder plan [Name]` | Define architecture and select UI framework |
+| `/design [Name]` | `$audio-plugin-coder:audio-plugin-coder design [Name]` | Create GUI mockups and visual design |
+| `/impl [Name]` | `$audio-plugin-coder:audio-plugin-coder impl [Name]` | Implement DSP and UI code |
+| `/ship [Name]` | `$audio-plugin-coder:audio-plugin-coder ship [Name]` | Package and distribute plugin |
+| `/status [Name]` | `$audio-plugin-coder:audio-plugin-coder status [Name]` | Check current progress and state |
+| `/resume [Name]` | `$audio-plugin-coder:audio-plugin-coder resume [Name]` | Continue development from last phase |
+| `/new [Name]` | `$audio-plugin-coder:audio-plugin-coder new [Name]` | Run complete workflow with confirmations |
+
+See [Codex Compatibility](docs/codex-compatibility.md) for setup details and the full command mapping.
 
 ### Example Session
 
@@ -189,6 +199,10 @@ APC uses a unique State Management system (status.json) to track development acr
 
 ```
 audio-plugin-coder/
+├── AGENTS.md                     # Agent guidance (AGENTS.md standard)
+├── .agents/skills/               # Codex repo-local skill discovery
+├── .codex-plugin/plugin.json     # Codex plugin manifest
+├── skills/                       # Packaged Codex skill
 ├── .[Agent]/                    # AI agent configuration
 │   ├── workflows/               # Slash command orchestrators
 │   │   ├── dream.md
@@ -298,11 +312,12 @@ APC includes an **auto-capture system** that learns from problems:
 ## 🤝 Compatible AI Agents
 
 APC works with any LLM-based coding agent that supports:
-- Custom workflows/slash commands
+- Custom workflows, skills, or reusable instructions
 - File system access
 - Shell execution (PowerShell on Windows, Bash on macOS/Linux)
 
-**Tested with:**
+**Supported:**
+- ✅ Codex CLI / IDE (repo skill and `AGENTS.md`)
 - ✅ Claude Code (Anthropic)
 - ✅ Kilo (kilo.ai)
 - [ ] Cursor
@@ -419,4 +434,3 @@ APC uses **JUCE 8** as its audio plugin framework. JUCE 8 is dual-licensed:
 **Built with ❤️ (and a lot of tokens) for the audio development community.**
 
 *Turn your plugin ideas into reality with the power of AI*
-

--- a/bin/setup.js
+++ b/bin/setup.js
@@ -181,12 +181,13 @@ function printNextSteps(platform, targetDir) {
   console.log(`     ${dim(`code "${targetDir}"`)}`);
   console.log('');
 
-  console.log(`  ${c.cyan}2.${c.reset} Install the Claude Code extension if you haven't already:`);
-  console.log(`     ${dim('https://marketplace.visualstudio.com/items?itemName=Anthropic.claude-code')}`);
+  console.log(`  ${c.cyan}2.${c.reset} Open the repository in your preferred AI coding agent.`);
+  console.log(`     ${dim('Codex, Claude Code, Kilo, Antigravity, or Cursor')}`);
   console.log('');
 
   console.log(`  ${c.cyan}3.${c.reset} Start your first plugin:`);
-  console.log(`     ${dim('/dream MyPluginName')}  ${dim('← type this inside Claude Code')}`);
+  console.log(`     ${dim('$audio-plugin-coder:audio-plugin-coder dream MyPluginName')}  ${dim('← Codex')}`);
+  console.log(`     ${dim('/dream MyPluginName')}                                        ${dim('← Claude Code / Kilo')}`);
   console.log('');
 
   if (platform === 'windows') {

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -288,6 +288,7 @@ git checkout -- plugins/MyPlugin/
 ### Which AI agents work with APC?
 
 **Tested:**
+- ✅ Codex (OpenAI)
 - ✅ Claude Code (Anthropic)
 - ✅ Antigravity (Google)
 - ✅ Kilo (kilo.ai)

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -8,14 +8,18 @@ APC follows a monorepo architecture with clear separation between framework code
 
 ```
 audio-plugin-coder/
-├── .agent/              # AI agent configuration and skills
+├── .agent/                 # AI agent configuration and skills
+├── .agents/                # Codex repo-local skill discovery
+├── .codex-plugin/          # Codex plugin manifest
 ├── _tools/                 # External dependencies (JUCE, pluginval)
 ├── build/                  # Build artifacts (gitignored)
 ├── dist/                   # Distribution packages (gitignored)
 ├── docs/                   # Documentation
 ├── plugins/                # Your plugin projects
 ├── scripts/                # Build and utility scripts
+├── skills/                 # Packaged Codex skill
 ├── .github/                # GitHub Actions workflows
+├── AGENTS.md               # Agent guidance (AGENTS.md standard)
 ├── CMakeLists.txt          # Root CMake configuration
 └── README.md               # Project overview
 ```
@@ -69,6 +73,21 @@ Contains all configuration, skills, and knowledge base for AI agents.
 - [`agent.md`](.agent/rules/agent.md) - Critical rules for AI agents
 - [`known-issues.yaml`](.agent/troubleshooting/known-issues.yaml) - Database of known issues
 - [`status-template.json`](.agent/templates/status-template.json) - Plugin state schema
+
+---
+
+### Codex Integration Files
+
+Codex discovers APC through dedicated files at the repository root:
+
+```
+AGENTS.md                    # Agent guidance (read by any AGENTS.md-aware agent)
+.agents/skills/              # Repo-local Codex skill (loader)
+.codex-plugin/plugin.json    # Codex plugin manifest
+skills/audio-plugin-coder/   # Packaged Codex skill
+```
+
+See [Codex Compatibility](codex-compatibility.md) for the command mapping and packaging details.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,8 @@ New to APC? Start here:
 1. **[Project Overview](../README.md)** - What is APC and key features
 2. **[Plugin Development Lifecycle](plugin-development-lifecycle.md)** - The five-phase workflow
 3. **[Command Reference](command-reference.md)** - All available commands
-4. **[FAQ](FAQ.md)** - Common questions answered
+4. **[Codex Compatibility](codex-compatibility.md)** - Codex setup and command mapping
+5. **[FAQ](FAQ.md)** - Common questions answered
 
 ## Documentation Index
 
@@ -20,6 +21,7 @@ New to APC? Start here:
 | [Project Structure](PROJECT_STRUCTURE.md) | Complete directory layout and file organization |
 | [Plugin Development Lifecycle](plugin-development-lifecycle.md) | Detailed guide to all five phases |
 | [Command Reference](command-reference.md) | All slash commands and PowerShell scripts |
+| [Codex Compatibility](codex-compatibility.md) | Codex skill, plugin manifest, and command mapping |
 | [FAQ](FAQ.md) | Frequently asked questions |
 
 ### Core Concepts
@@ -104,6 +106,8 @@ powershell -ExecutionPolicy Bypass -File .\scripts\build-and-install.ps1 -Plugin
 ```
 
 Full reference: [Command Reference](command-reference.md)
+
+Codex users should invoke these phases through `$audio-plugin-coder:audio-plugin-coder`; see [Codex Compatibility](codex-compatibility.md).
 
 ## UI Frameworks
 
@@ -200,4 +204,3 @@ APC is licensed under the MIT License. See [LICENSE](../LICENCE.md) for details.
 ---
 
 **Need help?** Check the [FAQ](FAQ.md) or review the [troubleshooting guide](troubleshooting-guide.md).
-

--- a/docs/codex-compatibility.md
+++ b/docs/codex-compatibility.md
@@ -1,0 +1,69 @@
+# Codex Compatibility
+
+Audio Plugin Coder supports Codex through a repository instruction file and a Codex skill adapter. The adapter routes Codex into APC's existing workflows and domain skills rather than duplicating them.
+
+## Compatibility Status
+
+| Capability | Codex support |
+|---|---|
+| Repository guidance | `AGENTS.md` |
+| Repo-local skill discovery | `.agents/skills/audio-plugin-coder/SKILL.md` |
+| Installable plugin manifest | `.codex-plugin/plugin.json` |
+| Packaged skill | `skills/audio-plugin-coder/SKILL.md` |
+| File editing and shell execution | Supported through Codex tools and approvals |
+| APC phase/state gating | Enforced by `AGENTS.md` and the APC skill |
+| APC legacy slash commands | Use the Codex mappings below |
+
+## Start in Codex
+
+Open the repository root in Codex CLI or the Codex IDE extension, then start a new session so repository skills are discovered.
+
+```text
+$audio-plugin-coder:audio-plugin-coder dream MyReverb
+```
+
+Codex can also select the skill from a natural-language request:
+
+```text
+Create a new APC audio plugin called MyReverb.
+```
+
+## Command Mapping
+
+APC's slash commands were designed for Claude Code and Kilo. In Codex, use the single skill with an action:
+
+| APC documentation | Codex |
+|---|---|
+| `/dream MyReverb` | `$audio-plugin-coder:audio-plugin-coder dream MyReverb` |
+| `/plan MyReverb` | `$audio-plugin-coder:audio-plugin-coder plan MyReverb` |
+| `/design MyReverb` | `$audio-plugin-coder:audio-plugin-coder design MyReverb` |
+| `/impl MyReverb` | `$audio-plugin-coder:audio-plugin-coder impl MyReverb` |
+| `/test MyReverb` | `$audio-plugin-coder:audio-plugin-coder test MyReverb` |
+| `/debug MyReverb` | `$audio-plugin-coder:audio-plugin-coder debug MyReverb` |
+| `/status MyReverb` | `$audio-plugin-coder:audio-plugin-coder status MyReverb` |
+| `/resume MyReverb` | `$audio-plugin-coder:audio-plugin-coder resume MyReverb` |
+| `/ship MyReverb` | `$audio-plugin-coder:audio-plugin-coder ship MyReverb` |
+| `/new MyReverb` | `$audio-plugin-coder:audio-plugin-coder new MyReverb` |
+
+Do not type `/plan` or `/status` to start APC phases in Codex. They are built-in Codex commands for plan mode and session status.
+
+## Repo Skill vs Plugin
+
+- **Working in this checkout:** no installation is required. Codex discovers the repo-local skill under `.agents/skills/`.
+- **Packaging for a marketplace:** the repository root is a valid Codex plugin package through `.codex-plugin/plugin.json`.
+- **Codex IDE extension:** use the repo-local skill. Installable plugins are available in Codex CLI and supported desktop surfaces, while repo skills work in the IDE extension.
+
+After changing skill metadata, start a new Codex session if the update does not appear immediately.
+
+## Design Notes
+
+- `AGENTS.md` carries durable repository rules because Codex does not read `.agent/rules/` automatically.
+- The adapter loads the existing `.claude/` workflow wrappers first, then falls back to the equivalent `.agent/` files.
+- A single `audio-plugin-coder` skill avoids duplicating APC's large domain knowledge base.
+- The adapter translates platform-specific examples and preserves APC's one-phase-at-a-time stopping rule.
+
+## Official Codex References
+
+- [Custom instructions with AGENTS.md](https://learn.chatgpt.com/docs/agent-configuration/agents-md)
+- [Build skills](https://learn.chatgpt.com/docs/build-skills)
+- [Build plugins](https://learn.chatgpt.com/docs/build-plugins)

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1,20 +1,44 @@
 # Command Reference
 
-Complete reference for all APC commands, slash commands, and PowerShell scripts.
+Complete reference for all APC agent commands and platform scripts.
 
 ## Overview
 
 APC provides multiple ways to interact with the system:
 - **Slash Commands** - AI agent commands (`/dream`, `/plan`, etc.)
+- **Codex Skill** - `$audio-plugin-coder:audio-plugin-coder <action> <Name>`
 - **PowerShell Scripts** - Build and utility scripts
 - **GitHub Actions** - CI/CD workflows
 - **Direct Tools** - Manual tool invocation
 
 ---
 
+## Codex Commands
+
+Codex discovers APC's repo-local skill from `.agents/skills/`. Use the skill name followed by the APC action:
+
+```text
+$audio-plugin-coder:audio-plugin-coder dream EchoReverb
+$audio-plugin-coder:audio-plugin-coder plan EchoReverb
+$audio-plugin-coder:audio-plugin-coder design EchoReverb
+$audio-plugin-coder:audio-plugin-coder impl EchoReverb
+$audio-plugin-coder:audio-plugin-coder test EchoReverb
+$audio-plugin-coder:audio-plugin-coder debug EchoReverb
+$audio-plugin-coder:audio-plugin-coder status EchoReverb
+$audio-plugin-coder:audio-plugin-coder resume EchoReverb
+$audio-plugin-coder:audio-plugin-coder ship EchoReverb
+$audio-plugin-coder:audio-plugin-coder new EchoReverb
+```
+
+Natural-language equivalents also work. Do not use `/plan` or `/status` for APC in Codex; those names invoke Codex's built-in plan mode and session status.
+
+See [Codex Compatibility](codex-compatibility.md) for discovery and packaging details.
+
+---
+
 ## Slash Commands
 
-Slash commands are the primary way to interact with APC through AI agents.
+Slash commands are the primary APC syntax in Claude Code and Kilo.
 
 ### `/dream [Name]`
 
@@ -584,4 +608,3 @@ gh workflow run build-release.yml -f plugin_name=MyPlugin -f platforms=all
 - [State Management](state-management-deep-dive.md) - How state is tracked
 - [GitHub Actions](github-actions.md) - CI/CD workflows
 - [Troubleshooting](troubleshooting-guide.md) - When commands fail
-

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "audio-plugin-coder",
   "version": "0.3.0",
-  "description": "AI-powered VST3/AU plugin development framework for JUCE 8 — build audio plugins with Claude Code using a five-phase workflow.",
+  "description": "AI-powered VST3/AU plugin development framework for JUCE 8 — build audio plugins with Codex, Claude Code, or Kilo using a five-phase workflow.",
   "keywords": [
     "audio",
     "vst",
@@ -10,6 +10,7 @@
     "plugin",
     "audio-plugin",
     "dsp",
+    "codex",
     "claude",
     "ai",
     "scaffolding"

--- a/skills/audio-plugin-coder/SKILL.md
+++ b/skills/audio-plugin-coder/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: audio-plugin-coder
+description: Run Audio Plugin Coder lifecycle actions for JUCE plugins, including dream, plan, design, implement, test, debug, status, resume, and ship. Use when the user asks to create or continue an APC audio plugin or mentions an APC phase.
+---
+
+# Audio Plugin Coder
+
+Use this skill to run APC's phase-gated audio-plugin workflow in an Audio Plugin Coder checkout.
+
+## Invocation
+
+Prefer either form:
+
+```text
+$audio-plugin-coder:audio-plugin-coder dream TapeDelay
+$audio-plugin-coder:audio-plugin-coder plan TapeDelay
+```
+
+Natural-language requests such as "design the TapeDelay plugin" also work.
+
+Do not use APC's legacy `/plan` or `/status` spellings in Codex. They collide with Codex's built-in commands. Treat every legacy slash command found in APC documentation as workflow notation only.
+
+## Preconditions
+
+1. Confirm the current workspace is an APC checkout by finding `templates/status-template.json`, `scripts/`, and `plugins/`.
+2. If those files are absent, explain that the workflow must run from an APC checkout and stop. Do not scaffold an unrelated repository from the installed plugin cache.
+3. Determine the requested action and plugin name from the prompt. Ask for a missing plugin name only when it cannot be inferred safely.
+4. Before changing an existing plugin, read `plugins/<PluginName>/status.json`.
+
+## Load APC Instructions
+
+Keep this adapter thin; load APC's existing knowledge just in time:
+
+1. Read `AGENTS.md`.
+2. Read `.claude/rules/juce-build-protocols.md` and `.claude/rules/file-naming-conventions.md` for implementation, build, test, debug, or ship actions.
+3. Read the workflow and primary instruction file from the routing table.
+4. If a routed `.claude/` file is missing, use the equivalent `.agent/` path.
+5. Resolve examples for the current OS: PowerShell on Windows, Bash/Zsh on macOS or Linux.
+
+## Action Routing
+
+| Action | Workflow | Primary instructions |
+|---|---|---|
+| `dream` | `.claude/workflows/dream.md` | `.claude/skills/dream/SKILL.md` or `.agent/skills/skill_ideation/SKILL.md` |
+| `plan` | `.claude/workflows/plan.md` | `.claude/skills/plan/SKILL.md` or `.agent/skills/skill_planning/SKILL.md` |
+| `design` | `.claude/workflows/design.md` | `.claude/skills/design/SKILL.md` or `.agent/skills/skill_design/SKILL.md` |
+| `impl` or `implement` | `.claude/workflows/impl.md` | `.claude/skills/impl/SKILL.md` or `.agent/skills/skill_implementation/SKILL.md` |
+| `test` | `.claude/workflows/test.md` | `.claude/skills/skill_testing/SKILL.md` |
+| `debug` | `.claude/workflows/debug.md` | `.claude/skills/debug/SKILL.md` and `.claude/skills/skill_troubleshooting/SKILL.md` |
+| `ship` | `.claude/workflows/ship.md` | `.claude/skills/ship/SKILL.md` or `.agent/skills/skill_packaging/SKILL.md` |
+| `status` | `.claude/workflows/status.md` | Read-only state inspection |
+| `resume` | `.claude/workflows/resume.md` | Route to the next incomplete phase, then complete only that phase |
+| `new` | `.claude/workflows/new.md` | Run one phase at a time and obtain each required user confirmation |
+
+For WebView design or implementation, also load `.claude/skills/skill_design_webview/SKILL.md` when present.
+
+## Execution Rules
+
+1. Enforce the prerequisite phase from `status.json`.
+2. Preserve the recorded `ui_framework`.
+3. Treat shell snippets in workflow files as intent, not as permission to use the wrong platform shell.
+4. Use the repository's state-management and build scripts instead of reimplementing their behavior.
+5. Search `.claude/troubleshooting/known-issues.yaml` before trial-and-error debugging.
+6. Preserve unrelated user changes and generated plugin projects.
+7. Validate the requested phase's outputs.
+8. Update state only after successful validation.
+9. Stop after the requested phase and report the next APC invocation using `$audio-plugin-coder:audio-plugin-coder`.

--- a/skills/audio-plugin-coder/agents/openai.yaml
+++ b/skills/audio-plugin-coder/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Audio Plugin Coder"
+  short_description: "Build JUCE plugins with APC's gated workflow"
+  default_prompt: "Use $audio-plugin-coder:audio-plugin-coder to start a new JUCE audio plugin."
+
+policy:
+  allow_implicit_invocation: true


### PR DESCRIPTION
## Summary

Adds OpenAI Codex support to APC alongside the existing Claude Code / Kilo workflows:

- **`AGENTS.md`** — repository guidance following the AGENTS.md standard (agent-neutral, with a Codex-specific section).
- **Repo-local skill** — `.agents/skills/audio-plugin-coder/` (Codex's discovery path) is a thin loader pointing at the packaged skill in `skills/audio-plugin-coder/`, so a plain checkout works with no installation.
- **`.codex-plugin/plugin.json`** — manifest making the repo root packageable as a Codex plugin for future marketplace distribution, with `agents/openai.yaml` interface metadata.
- **Docs** — new `docs/codex-compatibility.md` (setup + full command mapping), plus Codex entries in the README, command reference, FAQ, and project structure guide; `bin/setup.js` next-steps now cover Codex.

## How it works

The skill is a thin adapter, not a fork of APC's knowledge base: it routes each action (`dream`, `plan`, `design`, `impl`, `test`, `debug`, `status`, `resume`, `ship`, `new`) to the existing `.claude/workflows/*.md` and skill files, with `.agent/` fallbacks, and preserves APC's one-phase-at-a-time gating, `status.json` state management, and platform shell rules. Because `/plan` and `/status` are reserved Codex built-ins, Codex users invoke APC as:

```text
$audio-plugin-coder:audio-plugin-coder <action> <PluginName>
```

Natural-language requests also work (implicit invocation is enabled).

## Validation

Live-tested in Codex CLI on macOS against this branch (read-only sandbox):

- `/skills` discovers the repo-local skill, and `$` tab-completion produces exactly the documented invocation string.
- Explicit invocation (long and short form) and natural-language requests all load the loader → packaged `SKILL.md` chain.
- A `status CloudWash` run followed the skill spec end-to-end: checkout preconditions, OS detection, `AGENTS.md` and `.claude/workflows/status.md` reads, state access through `scripts/state-management.sh`, read-only throughout.
- `AGENTS.md` is ingested at session start — Codex recalls the `/plan` / `/status` reservation unprompted.
- Every routed path in the skill's table exists (`.claude/workflows/*`, `.claude/skills/*`, `.agent/skills/*` fallbacks); manifest fields and path resolution match the published Codex plugin schema; all referenced doc links resolve.

## Notes

- The plugin manifest only matters for future marketplace packaging — Codex CLI currently installs plugins from marketplace snapshots only, so the repo-local skill is the supported path today. `interface.capabilities` values are best-effort pending a public validator.
- `.codex-plugin/plugin.json` mirrors `version` from `package.json` (0.3.0); both need bumping at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
