### PR TITLE
Fix WebView docs that still instruct ES6 modules (webview-008)

### DIFF
--- a/.agent/rules/juce-build-protocols.md
+++ b/.agent/rules/juce-build-protocols.md
@@ -25,8 +25,8 @@
 - **Location:** HTML/JS/CSS files MUST reside in plugins/[Name]/Source/ui/public/.
 - **Forbidden:** Do NOT use plugin-root WebUI/ or Resources/web unless the plugin CMakeLists.txt explicitly embeds that path via juce_add_binary_data.
 - **Embedding:** Register web files with juce_add_binary_data([Name]_WebUI ...) and link the target to the plugin.
-- **JS Interop:** Copy the JUCE 9 interop drop-in to Source/ui/public/js/juce/index.js from _tools/JUCE/modules/juce_gui_extra/native/typescript/webview-interop/dist/index.js and load it in index.html BEFORE your own js/index.js.
-- **window.__JUCE__:** The raw snapshot exists at runtime, but native function calls require the js/juce/index.js interop layer — never rely on window.__JUCE__ directly without it.
+- **JS Interop (webview-008):** ALL JavaScript must be INLINE in Source/ui/public/index.html - ES6 modules and external .js files fail SILENTLY in WebView. To get window.Juce helpers, paste the interop drop-in (_tools/JUCE/modules/juce_gui_extra/native/typescript/webview-interop/dist/index.js) INTO index.html with its import/export statements removed.
+- **window.__JUCE__:** The raw snapshot exists at runtime, but native function calls require the js/juce/index.js interop layer  — after inlining, call helpers via const Juce = window.Juce; window.__JUCE__ alone cannot make native calls.
 - **C++ Pathing:** In PluginEditor.cpp, serve files via WebBrowserComponent .withResourceProvider() over the embedded binary data.
 ### B. CMake Configuration
 - **Root:** The Root CMakeLists.txt loads JUCE.

--- a/.agent/skills/design/SKILL.md
+++ b/.agent/skills/design/SKILL.md
@@ -280,7 +280,7 @@ Generate **`$PluginPath/Design/v1-test.html`** - **WORKING HTML PREVIEW**:
      <meta charset="UTF-8">
      <meta name="viewport" content="width=device-width, initial-scale=1.0">
      <title>[Name] Plugin</title>
-     <script type="module" src="js/index.js"></script>
+     <!-- webview-008: ALL JavaScript must be INLINE - external scripts fail silently -->
      <style>
        /* Complete CSS based on style guide */
        :root {
@@ -320,7 +320,7 @@ Generate **`$PluginPath/Design/v1-test.html`** - **WORKING HTML PREVIEW**:
 
    **JavaScript placeholder (for preview only):**
    ```javascript
-   // This is a placeholder for preview - actual implementation goes in Source/ui/public/js/index.js
+   // This is a placeholder for preview - actual implementation goes INLINE in Source/ui/public/index.html
    document.addEventListener("DOMContentLoaded", () => {
        console.log("Preview mode - UI structure loaded");
        // Preview-only code here
@@ -330,7 +330,7 @@ Generate **`$PluginPath/Design/v1-test.html`** - **WORKING HTML PREVIEW**:
    **For WebView plugins:** The HTML in `v1-test.html` should be **identical** to what will be in `Source/ui/public/index.html` (minus the preview JavaScript).
 
    **CRITICAL WebView Requirements:**
-   - HTML must use `<script type="module">` for JavaScript imports
+   - ALL JavaScript must be inline in ONE `<script>` block - ES6 modules fail silently in JUCE WebView (webview-008)
    - All element IDs must match parameter IDs from `parameter-spec.md`
    - CSS must be complete and production-ready (embedded in `<style>` tag)
    - HTML structure must match the approved design exactly

--- a/.agent/skills/impl/SKILL.md
+++ b/.agent/skills/impl/SKILL.md
@@ -55,23 +55,17 @@ Convert the approved design specs into production JUCE WebView code.
 **Create the required directory structure:**
 ```
 $PluginPath/Source/ui/
-â””â”€â”€â”€public/
-    â”‚   index.html          # Production UI based on approved design
-    â”‚
-    â””â”€â”€â”€js/
-        â”‚   index.js        # JUCE integration and parameter binding
-        â”‚
-        â””â”€â”€â”€juce/
-                check_native_interop.js  # Development utility
-                index.js                # JUCE frontend library
+└───public/
+    │   index.html          # Production UI based on approved design - ALL CSS/JS inline (webview-008)
+    │   test-local.html     # Browser-test copy of index.html
 ```
 
 **Implementation Steps:**
-1. **Create directories:** `$PluginPath/Source/ui/public/` and subdirectories
-2. **Copy JUCE frontend library:** Copy `modules/juce_gui_extra/native/javascript/index.js` to `js/juce/index.js`
-3. **Create interop checker:** Generate `js/juce/check_native_interop.js` for development
-4. **Convert design to HTML:** Transform approved design specs into `index.html` with embedded CSS
-5. **Generate JavaScript:** Create `js/index.js` with parameter state setup and UI controls
+1. **Create directory:** `$PluginPath/Source/ui/public/`
+2. **Inline the JUCE frontend library:** Take `_tools/JUCE/modules/juce_gui_extra/native/typescript/webview-interop/dist/index.js`, remove its `import`/`export` statements, expose it as `window.Juce`, and paste it into a single `<script>` block in `index.html` (ES6 modules fail silently in WebView - webview-008)
+3. **Convert design to HTML:** Transform approved design specs into `index.html` with embedded CSS
+4. **Inline UI JavaScript:** Append parameter state setup and UI controls to the SAME `<script>` block - NO external `.js` files
+5. **Create browser-test copy:** Duplicate `index.html` as `test-local.html`
 
 **Conversion Process:**
 - Extract layout, colors, and styling from `v[N]-style-guide.md`
@@ -90,7 +84,7 @@ $PluginPath/Source/ui/
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>[Name] Plugin</title>
-  <script type="module" src="js/index.js"></script>
+  <!-- webview-008: ALL JavaScript must be INLINE - external scripts fail silently -->
   <style>
     /* Styles based on approved v[N]-style-guide.md */
     body {
@@ -112,9 +106,10 @@ $PluginPath/Source/ui/
 </html>
 ```
 
-**ui/public/js/index.js:**
+**Inline JavaScript (inside ui/public/index.html):**
 ```javascript
-import * as Juce from "./juce/index.js";
+// NO imports allowed (webview-008):
+const Juce = window.Juce;
 
 // Initialize parameter states from parameter-spec.md
 const parameterStates = {};
@@ -136,9 +131,7 @@ function initializeUI() {
 âœ… Design converted to WebView code
 
 Files created:
-- $PluginPath/Source/ui/public/index.html
-- $PluginPath/Source/ui/public/js/index.js
-- $PluginPath/Source/ui/public/js/juce/index.js
+- $PluginPath/Source/ui/public/index.html (ALL JavaScript inline)
 
 âš ï¸ **MANDATORY STOP** - You MUST test the WebView setup before proceeding to DSP implementation!
 
@@ -311,7 +304,7 @@ See: `..agent/troubleshooting/resolutions/webview-member-order-crash.md`
 1. Review error messages from validation script
 2. Check templates in `templates/webview/`
 3. Compare your code with JUCE example: `_tools/JUCE/examples/Plugins/WebViewPluginDemo.h`
-4. Ensure web files exist: `Source/ui/public/index.html`, `js/index.js`, `js/juce/index.js`
+4. Ensure `Source/ui/public/index.html` exists with ALL JavaScript inline (no separate .js files)
 5. Verify CMakeLists.txt embeds files correctly
 
 **DO NOT PROCEED TO DSP IMPLEMENTATION UNTIL ALL 8 CHECKS PASS**

--- a/.agent/skills/skill_design/SKILL.md
+++ b/.agent/skills/skill_design/SKILL.md
@@ -280,7 +280,7 @@ Generate **`$PluginPath/Design/v1-test.html`** - **WORKING HTML PREVIEW**:
      <meta charset="UTF-8">
      <meta name="viewport" content="width=device-width, initial-scale=1.0">
      <title>[Name] Plugin</title>
-     <script type="module" src="js/index.js"></script>
+     <!-- webview-008: ALL JavaScript must be INLINE - external scripts fail silently -->
      <style>
        /* Complete CSS based on style guide */
        :root {
@@ -320,7 +320,7 @@ Generate **`$PluginPath/Design/v1-test.html`** - **WORKING HTML PREVIEW**:
 
    **JavaScript placeholder (for preview only):**
    ```javascript
-   // This is a placeholder for preview - actual implementation goes in Source/ui/public/js/index.js
+   // This is a placeholder for preview - actual implementation goes INLINE in Source/ui/public/index.html
    document.addEventListener("DOMContentLoaded", () => {
        console.log("Preview mode - UI structure loaded");
        // Preview-only code here
@@ -330,7 +330,7 @@ Generate **`$PluginPath/Design/v1-test.html`** - **WORKING HTML PREVIEW**:
    **For WebView plugins:** The HTML in `v1-test.html` should be **identical** to what will be in `Source/ui/public/index.html` (minus the preview JavaScript).
 
    **CRITICAL WebView Requirements:**
-   - HTML must use `<script type="module">` for JavaScript imports
+   - ALL JavaScript must be inline in ONE `<script>` block - ES6 modules fail silently in JUCE WebView (webview-008)
    - All element IDs must match parameter IDs from `parameter-spec.md`
    - CSS must be complete and production-ready (embedded in `<style>` tag)
    - HTML structure must match the approved design exactly

--- a/.agent/skills/skill_design_webview/SKILL.md
+++ b/.agent/skills/skill_design_webview/SKILL.md
@@ -78,6 +78,8 @@ plugins/YourPlugin/
                 â””â”€â”€ index.js
 ```
 
+> **CRITICAL (webview-008):** ES6 modules fail in JUCE WebView - there must be NO separate .js files and no external scripts. Everything goes inline into ONE <script> block in index.html.
+
 ### Step 2: Write index.html
 
 ```html
@@ -86,7 +88,7 @@ plugins/YourPlugin/
 <head>
   <meta charset="UTF-8">
   <title>My Plugin</title>
-  <script type="module" src="js/index.js"></script>
+  <!-- webview-008: ALL JavaScript must be INLINE - external scripts fail silently -->
   <style>
     body {
       margin: 0;
@@ -109,10 +111,12 @@ plugins/YourPlugin/
 </html>
 ```
 
-### Step 3: Write index.js
+### Step 3: Inline JavaScript (inside index.html)
+
+> **CRITICAL (webview-008):** ES6 modules do NOT work in JUCE WebView. Never create separate `.js` files. Inline ALL JavaScript - including the JUCE frontend library exposed as `window.Juce` - in ONE `<script>` block.
 
 ```javascript
-import * as Juce from "./juce/index.js";
+const Juce = window.Juce; // JUCE library INLINED above - never use import/export (webview-008)
 
 document.addEventListener("DOMContentLoaded", () => {
     // Get parameter state from C++
@@ -145,9 +149,7 @@ document.addEventListener("DOMContentLoaded", () => {
 juce_add_binary_data(YourPlugin_WebUI
     SOURCES
         Source/ui/public/index.html
-        Source/ui/public/js/index.js
-        Source/ui/public/js/juce/index.js
-        Source/ui/public/js/juce/check_native_interop.js
+        # NO JS FILES - all JavaScript must be inline in index.html (webview-008)
 )
 
 # Plugin definition
@@ -428,13 +430,13 @@ gainAttachment = std::make_unique<...>(...);  // Too early
 webView = std::make_unique<...>(...);         // Too late
 ```
 
-### âŒ Not Embedding All Files
+### âŒ Embedding Separate JS Files
 ```cmake
-# WRONG - Missing JS files!
+# WRONG - JS files are never loaded (ES6 modules fail - webview-008)!
 juce_add_binary_data(Plugin_WebUI
     SOURCES
         Source/ui/public/index.html
-        # Missing: js files!
+        Source/ui/public/js/index.js   # NOT loaded - must be inlined instead!
 )
 ```
 

--- a/.agent/skills/skill_design_webview/SKILL_OLD.md
+++ b/.agent/skills/skill_design_webview/SKILL_OLD.md
@@ -701,7 +701,7 @@ your-plugin/
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>My Web Plugin</title>
-  <script type="module" src="js/index.js"></script>
+  <!-- webview-008: ALL JavaScript must be INLINE - external scripts fail silently -->
   <style>
     /* Modern dark theme */
     body {
@@ -746,7 +746,7 @@ your-plugin/
 ### Step 3: Write index.js
 
 ```javascript
-import * as Juce from "./juce/index.js";
+// const Juce = window.Juce;  // inlined library (webview-008: no imports)
 
 // Wait for DOM
 document.addEventListener("DOMContentLoaded", () => {
@@ -1349,12 +1349,12 @@ target_link_libraries(MyPlugin
 **WRONG:**
 ```html
 <!-- index.html -->
-<script type="module" src="js/index.js"></script>
+<!-- webview-008: ALL JavaScript must be INLINE - external scripts fail silently -->
 ```
 
 ```javascript
 // js/index.js
-import * as Juce from "./juce/index.js";  // File doesn't exist!
+const Juce = window.Juce;  // inlined - imports fail (webview-008)!
 ```
 
 **WHY IT FAILS:** JUCE frontend library (`juce/index.js`) must be copied from JUCE modules to your project.

--- a/.agent/skills/skill_implementation/SKILL.md
+++ b/.agent/skills/skill_implementation/SKILL.md
@@ -56,22 +56,16 @@ Convert the approved design specs into production JUCE WebView code.
 ```
 $PluginPath/Source/ui/
 └───public/
-    │   index.html          # Production UI based on approved design
-    │
-    └───js/
-        │   index.js        # JUCE integration and parameter binding
-        │
-        └───juce/
-                check_native_interop.js  # Development utility
-                index.js                # JUCE frontend library
+    │   index.html          # Production UI based on approved design - ALL CSS/JS inline (webview-008)
+    │   test-local.html     # Browser-test copy of index.html
 ```
 
 **Implementation Steps:**
-1. **Create directories:** `$PluginPath/Source/ui/public/` and subdirectories
-2. **Copy JUCE frontend library:** Copy `modules/juce_gui_extra/native/javascript/index.js` to `js/juce/index.js`
-3. **Create interop checker:** Generate `js/juce/check_native_interop.js` for development
-4. **Convert design to HTML:** Transform approved design specs into `index.html` with embedded CSS
-5. **Generate JavaScript:** Create `js/index.js` with parameter state setup and UI controls
+1. **Create directory:** `$PluginPath/Source/ui/public/`
+2. **Inline the JUCE frontend library:** Take `_tools/JUCE/modules/juce_gui_extra/native/typescript/webview-interop/dist/index.js`, remove its `import`/`export` statements, expose it as `window.Juce`, and paste it into a single `<script>` block in `index.html` (ES6 modules fail silently in WebView - webview-008)
+3. **Convert design to HTML:** Transform approved design specs into `index.html` with embedded CSS
+4. **Inline UI JavaScript:** Append parameter state setup and UI controls to the SAME `<script>` block - NO external `.js` files
+5. **Create browser-test copy:** Duplicate `index.html` as `test-local.html`
 
 **Conversion Process:**
 - Extract layout, colors, and styling from `v[N]-style-guide.md`
@@ -90,7 +84,7 @@ $PluginPath/Source/ui/
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>[Name] Plugin</title>
-  <script type="module" src="js/index.js"></script>
+  <!-- webview-008: ALL JavaScript must be INLINE - external scripts fail silently -->
   <style>
     /* Styles based on approved v[N]-style-guide.md */
     body {
@@ -112,9 +106,10 @@ $PluginPath/Source/ui/
 </html>
 ```
 
-**ui/public/js/index.js:**
+**Inline JavaScript (inside ui/public/index.html):**
 ```javascript
-import * as Juce from "./juce/index.js";
+// NO imports allowed (webview-008):
+const Juce = window.Juce;
 
 // Initialize parameter states from parameter-spec.md
 const parameterStates = {};
@@ -136,9 +131,7 @@ function initializeUI() {
 ✅ Design converted to WebView code
 
 Files created:
-- $PluginPath/Source/ui/public/index.html
-- $PluginPath/Source/ui/public/js/index.js
-- $PluginPath/Source/ui/public/js/juce/index.js
+- $PluginPath/Source/ui/public/index.html (ALL JavaScript inline)
 
 ⚠️ **MANDATORY STOP** - You MUST test the WebView setup before proceeding to DSP implementation!
 
@@ -311,7 +304,7 @@ See: `..agent/troubleshooting/resolutions/webview-member-order-crash.md`
 1. Review error messages from validation script
 2. Check templates in `templates/webview/`
 3. Compare your code with JUCE example: `_tools/JUCE/examples/Plugins/WebViewPluginDemo.h`
-4. Ensure web files exist: `Source/ui/public/index.html`, `js/index.js`, `js/juce/index.js`
+4. Ensure `Source/ui/public/index.html` exists with ALL JavaScript inline (no separate .js files)
 5. Verify CMakeLists.txt embeds files correctly
 
 **DO NOT PROCEED TO DSP IMPLEMENTATION UNTIL ALL 8 CHECKS PASS**

--- a/.agent/troubleshooting/resolutions/webview-blank-screen.md
+++ b/.agent/troubleshooting/resolutions/webview-blank-screen.md
@@ -143,7 +143,7 @@ webView->loadHTML(htmlString);  // ❌ Can't load external JS
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <script type="module" src="js/index.js"></script>
+  <!-- webview-008: ALL JavaScript must be INLINE - external scripts fail silently -->
 </head>
 <body>
   <!-- Your UI here -->
@@ -152,17 +152,17 @@ webView->loadHTML(htmlString);  // ❌ Can't load external JS
 ```
 
 **Common issues:**
-- Missing `type="module"` → JavaScript won't load
-- Wrong path to `js/index.js` → File not found
+- Any `<script src="...">` tag → silent failure (webview-008); inline all JS
+- Any `import` statement → fails silently (webview-008)
 - Missing closing tags → HTML parsing fails
 
 ---
 
 ## Step 7: Check JavaScript Initialization
 
-**Verify js/index.js:**
+**Verify inline JavaScript (in index.html):**
 ```javascript
-import * as Juce from "./juce/index.js";
+const Juce = window.Juce; // JUCE library INLINED above - never use import/export (webview-008)
 
 document.addEventListener("DOMContentLoaded", () => {
     console.log("UI initialized");  // Check if this appears in console
@@ -171,8 +171,7 @@ document.addEventListener("DOMContentLoaded", () => {
 ```
 
 **If console shows errors:**
-- Check import path is correct
-- Verify `juce/index.js` exists
+- Look for leftover `import`/`export` statements or `<script src>` tags (webview-008)
 - Check for syntax errors in JavaScript
 
 ---
@@ -229,9 +228,9 @@ Run through this checklist:
 - [ ] WebBrowserComponent uses `.withResourceProvider()`
 - [ ] Uses `getResourceProviderRoot()` not data URI
 - [ ] Parameter relays created BEFORE WebBrowserComponent
-- [ ] Web files exist: `index.html`, `js/index.js`, `js/juce/index.js`
-- [ ] HTML has `<script type="module" src="js/index.js"></script>`
-- [ ] JavaScript imports JUCE library correctly
+- [ ] `index.html` exists with ALL JavaScript inline (no separate .js files)
+- [ ] HTML has NO `<script src="...">` tags and NO import/export statements (webview-008)
+- [ ] Inline `<script>` block defines `window.Juce` before UI code runs
 - [ ] Plugin rebuilt after making changes
 
 ---
@@ -241,7 +240,7 @@ Run through this checklist:
 | Symptom | Solution |
 |---------|----------|
 | Blank screen, no console errors | Check WebView2 runtime installation |
-| Console: "Failed to load module" | Copy JUCE frontend library to `js/juce/index.js` |
+| Console: CORS / module errors | Inline ALL JS into `index.html`, incl. JUCE library (webview-008) |
 | Console: "404 Not Found" | Fix resource provider or verify files embedded |
 | Console: "backend is undefined" | Add `.withNativeIntegrationEnabled()` |
 | Console: "CORS error" | Check resource provider implementation |

--- a/.claude/rules/juce-build-protocols.md
+++ b/.claude/rules/juce-build-protocols.md
@@ -25,8 +25,8 @@
 - **Location:** HTML/JS/CSS files MUST reside in plugins/[Name]/Source/ui/public/.
 - **Forbidden:** Do NOT use plugin-root WebUI/ or Resources/web unless the plugin CMakeLists.txt explicitly embeds that path via juce_add_binary_data.
 - **Embedding:** Register web files with juce_add_binary_data([Name]_WebUI ...) and link the target to the plugin.
-- **JS Interop:** Copy the JUCE 9 interop drop-in to Source/ui/public/js/juce/index.js from _tools/JUCE/modules/juce_gui_extra/native/typescript/webview-interop/dist/index.js and load it in index.html BEFORE your own js/index.js.
-- **window.__JUCE__:** The raw snapshot exists at runtime, but native function calls require the js/juce/index.js interop layer — never rely on window.__JUCE__ directly without it.
+- **JS Interop (webview-008):** ALL JavaScript must be INLINE in Source/ui/public/index.html - ES6 modules and external .js files fail SILENTLY in WebView. To get window.Juce helpers, paste the interop drop-in (_tools/JUCE/modules/juce_gui_extra/native/typescript/webview-interop/dist/index.js) INTO index.html with its import/export statements removed.
+- **window.__JUCE__:** The raw snapshot exists at runtime, but native function calls require the js/juce/index.js interop layer  — after inlining, call helpers via const Juce = window.Juce; window.__JUCE__ alone cannot make native calls.
 - **C++ Pathing:** In PluginEditor.cpp, serve files via WebBrowserComponent .withResourceProvider() over the embedded binary data.
 ### B. CMake Configuration
 - **Root:** The Root CMakeLists.txt loads JUCE.

--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -280,7 +280,7 @@ Generate **`$PluginPath/Design/v1-test.html`** - **WORKING HTML PREVIEW**:
      <meta charset="UTF-8">
      <meta name="viewport" content="width=device-width, initial-scale=1.0">
      <title>[Name] Plugin</title>
-     <script type="module" src="js/index.js"></script>
+     <!-- webview-008: ALL JavaScript must be INLINE - external scripts fail silently -->
      <style>
        /* Complete CSS based on style guide */
        :root {
@@ -320,7 +320,7 @@ Generate **`$PluginPath/Design/v1-test.html`** - **WORKING HTML PREVIEW**:
 
    **JavaScript placeholder (for preview only):**
    ```javascript
-   // This is a placeholder for preview - actual implementation goes in Source/ui/public/js/index.js
+   // This is a placeholder for preview - actual implementation goes INLINE in Source/ui/public/index.html
    document.addEventListener("DOMContentLoaded", () => {
        console.log("Preview mode - UI structure loaded");
        // Preview-only code here
@@ -330,7 +330,7 @@ Generate **`$PluginPath/Design/v1-test.html`** - **WORKING HTML PREVIEW**:
    **For WebView plugins:** The HTML in `v1-test.html` should be **identical** to what will be in `Source/ui/public/index.html` (minus the preview JavaScript).
 
    **CRITICAL WebView Requirements:**
-   - HTML must use `<script type="module">` for JavaScript imports
+   - ALL JavaScript must be inline in ONE `<script>` block - ES6 modules fail silently in JUCE WebView (webview-008)
    - All element IDs must match parameter IDs from `parameter-spec.md`
    - CSS must be complete and production-ready (embedded in `<style>` tag)
    - HTML structure must match the approved design exactly

--- a/.claude/skills/impl/SKILL.md
+++ b/.claude/skills/impl/SKILL.md
@@ -56,22 +56,16 @@ Convert the approved design specs into production JUCE WebView code.
 ```
 $PluginPath/Source/ui/
 └───public/
-    │   index.html          # Production UI based on approved design
-    │
-    └───js/
-        │   index.js        # JUCE integration and parameter binding
-        │
-        └───juce/
-                check_native_interop.js  # Development utility
-                index.js                # JUCE frontend library
+    │   index.html          # Production UI based on approved design - ALL CSS/JS inline (webview-008)
+    │   test-local.html     # Browser-test copy of index.html
 ```
 
 **Implementation Steps:**
-1. **Create directories:** `$PluginPath/Source/ui/public/` and subdirectories
-2. **Copy JUCE frontend library:** Copy `modules/juce_gui_extra/native/javascript/index.js` to `js/juce/index.js`
-3. **Create interop checker:** Generate `js/juce/check_native_interop.js` for development
-4. **Convert design to HTML:** Transform approved design specs into `index.html` with embedded CSS
-5. **Generate JavaScript:** Create `js/index.js` with parameter state setup and UI controls
+1. **Create directory:** `$PluginPath/Source/ui/public/`
+2. **Inline the JUCE frontend library:** Take `_tools/JUCE/modules/juce_gui_extra/native/typescript/webview-interop/dist/index.js`, remove its `import`/`export` statements, expose it as `window.Juce`, and paste it into a single `<script>` block in `index.html` (ES6 modules fail silently in WebView - webview-008)
+3. **Convert design to HTML:** Transform approved design specs into `index.html` with embedded CSS
+4. **Inline UI JavaScript:** Append parameter state setup and UI controls to the SAME `<script>` block - NO external `.js` files
+5. **Create browser-test copy:** Duplicate `index.html` as `test-local.html`
 
 **Conversion Process:**
 - Extract layout, colors, and styling from `v[N]-style-guide.md`
@@ -90,7 +84,7 @@ $PluginPath/Source/ui/
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>[Name] Plugin</title>
-  <script type="module" src="js/index.js"></script>
+  <!-- webview-008: ALL JavaScript must be INLINE - external scripts fail silently -->
   <style>
     /* Styles based on approved v[N]-style-guide.md */
     body {
@@ -112,9 +106,10 @@ $PluginPath/Source/ui/
 </html>
 ```
 
-**ui/public/js/index.js:**
+**Inline JavaScript (inside ui/public/index.html):**
 ```javascript
-import * as Juce from "./juce/index.js";
+// NO imports allowed (webview-008):
+const Juce = window.Juce;
 
 // Initialize parameter states from parameter-spec.md
 const parameterStates = {};
@@ -136,9 +131,7 @@ function initializeUI() {
 ✅ Design converted to WebView code
 
 Files created:
-- $PluginPath/Source/ui/public/index.html
-- $PluginPath/Source/ui/public/js/index.js
-- $PluginPath/Source/ui/public/js/juce/index.js
+- $PluginPath/Source/ui/public/index.html (ALL JavaScript inline)
 
 ⚠️ **MANDATORY STOP** - You MUST test the WebView setup before proceeding to DSP implementation!
 
@@ -311,7 +304,7 @@ See: `.claude/troubleshooting/resolutions/webview-member-order-crash.md`
 1. Review error messages from validation script
 2. Check templates in `templates/webview/`
 3. Compare your code with JUCE example: `_tools/JUCE/examples/Plugins/WebViewPluginDemo.h`
-4. Ensure web files exist: `Source/ui/public/index.html`, `js/index.js`, `js/juce/index.js`
+4. Ensure `Source/ui/public/index.html` exists with ALL JavaScript inline (no separate .js files)
 5. Verify CMakeLists.txt embeds files correctly
 
 **DO NOT PROCEED TO DSP IMPLEMENTATION UNTIL ALL 8 CHECKS PASS**

--- a/.claude/skills/skill_design_webview/SKILL.md
+++ b/.claude/skills/skill_design_webview/SKILL.md
@@ -78,6 +78,8 @@ plugins/YourPlugin/
                 └── index.js
 ```
 
+> **CRITICAL (webview-008):** ES6 modules fail in JUCE WebView - there must be NO separate .js files and no external scripts. Everything goes inline into ONE <script> block in index.html.
+
 ### Step 2: Write index.html
 
 ```html
@@ -86,7 +88,7 @@ plugins/YourPlugin/
 <head>
   <meta charset="UTF-8">
   <title>My Plugin</title>
-  <script type="module" src="js/index.js"></script>
+  <!-- webview-008: ALL JavaScript must be INLINE - external scripts fail silently -->
   <style>
     body {
       margin: 0;
@@ -109,10 +111,12 @@ plugins/YourPlugin/
 </html>
 ```
 
-### Step 3: Write index.js
+### Step 3: Inline JavaScript (inside index.html)
+
+> **CRITICAL (webview-008):** ES6 modules do NOT work in JUCE WebView. Never create separate `.js` files. Inline ALL JavaScript - including the JUCE frontend library exposed as `window.Juce` - in ONE `<script>` block.
 
 ```javascript
-import * as Juce from "./juce/index.js";
+const Juce = window.Juce; // JUCE library INLINED above - never use import/export (webview-008)
 
 document.addEventListener("DOMContentLoaded", () => {
     // Get parameter state from C++
@@ -145,9 +149,7 @@ document.addEventListener("DOMContentLoaded", () => {
 juce_add_binary_data(YourPlugin_WebUI
     SOURCES
         Source/ui/public/index.html
-        Source/ui/public/js/index.js
-        Source/ui/public/js/juce/index.js
-        Source/ui/public/js/juce/check_native_interop.js
+        # NO JS FILES - all JavaScript must be inline in index.html (webview-008)
 )
 
 # Plugin definition
@@ -428,13 +430,13 @@ gainAttachment = std::make_unique<...>(...);  // Too early
 webView = std::make_unique<...>(...);         // Too late
 ```
 
-### ❌ Not Embedding All Files
+### ❌ Embedding Separate JS Files
 ```cmake
-# WRONG - Missing JS files!
+# WRONG - JS files are never loaded (ES6 modules fail - webview-008)!
 juce_add_binary_data(Plugin_WebUI
     SOURCES
         Source/ui/public/index.html
-        # Missing: js files!
+        Source/ui/public/js/index.js   # NOT loaded - must be inlined instead!
 )
 ```
 

--- a/.claude/troubleshooting/resolutions/webview-blank-screen.md
+++ b/.claude/troubleshooting/resolutions/webview-blank-screen.md
@@ -143,7 +143,7 @@ webView->loadHTML(htmlString);  // ❌ Can't load external JS
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <script type="module" src="js/index.js"></script>
+  <!-- webview-008: ALL JavaScript must be INLINE - external scripts fail silently -->
 </head>
 <body>
   <!-- Your UI here -->
@@ -152,17 +152,17 @@ webView->loadHTML(htmlString);  // ❌ Can't load external JS
 ```
 
 **Common issues:**
-- Missing `type="module"` → JavaScript won't load
-- Wrong path to `js/index.js` → File not found
+- Any `<script src="...">` tag → silent failure (webview-008); inline all JS
+- Any `import` statement → fails silently (webview-008)
 - Missing closing tags → HTML parsing fails
 
 ---
 
 ## Step 7: Check JavaScript Initialization
 
-**Verify js/index.js:**
+**Verify inline JavaScript (in index.html):**
 ```javascript
-import * as Juce from "./juce/index.js";
+const Juce = window.Juce; // JUCE library INLINED above - never use import/export (webview-008)
 
 document.addEventListener("DOMContentLoaded", () => {
     console.log("UI initialized");  // Check if this appears in console
@@ -171,8 +171,7 @@ document.addEventListener("DOMContentLoaded", () => {
 ```
 
 **If console shows errors:**
-- Check import path is correct
-- Verify `juce/index.js` exists
+- Look for leftover `import`/`export` statements or `<script src>` tags (webview-008)
 - Check for syntax errors in JavaScript
 
 ---
@@ -229,9 +228,9 @@ Run through this checklist:
 - [ ] WebBrowserComponent uses `.withResourceProvider()`
 - [ ] Uses `getResourceProviderRoot()` not data URI
 - [ ] Parameter relays created BEFORE WebBrowserComponent
-- [ ] Web files exist: `index.html`, `js/index.js`, `js/juce/index.js`
-- [ ] HTML has `<script type="module" src="js/index.js"></script>`
-- [ ] JavaScript imports JUCE library correctly
+- [ ] `index.html` exists with ALL JavaScript inline (no separate .js files)
+- [ ] HTML has NO `<script src="...">` tags and NO import/export statements (webview-008)
+- [ ] Inline `<script>` block defines `window.Juce` before UI code runs
 - [ ] Plugin rebuilt after making changes
 
 ---
@@ -241,7 +240,7 @@ Run through this checklist:
 | Symptom | Solution |
 |---------|----------|
 | Blank screen, no console errors | Check WebView2 runtime installation |
-| Console: "Failed to load module" | Copy JUCE frontend library to `js/juce/index.js` |
+| Console: CORS / module errors | Inline ALL JS into `index.html`, incl. JUCE library (webview-008) |
 | Console: "404 Not Found" | Fix resource provider or verify files embedded |
 | Console: "backend is undefined" | Add `.withNativeIntegrationEnabled()` |
 | Console: "CORS error" | Check resource provider implementation |

--- a/.kilocode/rules/juce-build-protocols.md
+++ b/.kilocode/rules/juce-build-protocols.md
@@ -25,8 +25,8 @@
 - **Location:** HTML/JS/CSS files MUST reside in plugins/[Name]/Source/ui/public/.
 - **Forbidden:** Do NOT use plugin-root WebUI/ or Resources/web unless the plugin CMakeLists.txt explicitly embeds that path via juce_add_binary_data.
 - **Embedding:** Register web files with juce_add_binary_data([Name]_WebUI ...) and link the target to the plugin.
-- **JS Interop:** Copy the JUCE 9 interop drop-in to Source/ui/public/js/juce/index.js from _tools/JUCE/modules/juce_gui_extra/native/typescript/webview-interop/dist/index.js and load it in index.html BEFORE your own js/index.js.
-- **window.__JUCE__:** The raw snapshot exists at runtime, but native function calls require the js/juce/index.js interop layer — never rely on window.__JUCE__ directly without it.
+- **JS Interop (webview-008):** ALL JavaScript must be INLINE in Source/ui/public/index.html - ES6 modules and external .js files fail SILENTLY in WebView. To get window.Juce helpers, paste the interop drop-in (_tools/JUCE/modules/juce_gui_extra/native/typescript/webview-interop/dist/index.js) INTO index.html with its import/export statements removed.
+- **window.__JUCE__:** The raw snapshot exists at runtime, but native function calls require the js/juce/index.js interop layer  — after inlining, call helpers via const Juce = window.Juce; window.__JUCE__ alone cannot make native calls.
 - **C++ Pathing:** In PluginEditor.cpp, serve files via WebBrowserComponent .withResourceProvider() over the embedded binary data.
 ### B. CMake Configuration
 - **Root:** The Root CMakeLists.txt loads JUCE.

--- a/.kilocode/skills/design/SKILL.md
+++ b/.kilocode/skills/design/SKILL.md
@@ -280,7 +280,7 @@ Generate **`$PluginPath/Design/v1-test.html`** - **WORKING HTML PREVIEW**:
      <meta charset="UTF-8">
      <meta name="viewport" content="width=device-width, initial-scale=1.0">
      <title>[Name] Plugin</title>
-     <script type="module" src="js/index.js"></script>
+     <!-- webview-008: ALL JavaScript must be INLINE - external scripts fail silently -->
      <style>
        /* Complete CSS based on style guide */
        :root {
@@ -320,7 +320,7 @@ Generate **`$PluginPath/Design/v1-test.html`** - **WORKING HTML PREVIEW**:
 
    **JavaScript placeholder (for preview only):**
    ```javascript
-   // This is a placeholder for preview - actual implementation goes in Source/ui/public/js/index.js
+   // This is a placeholder for preview - actual implementation goes INLINE in Source/ui/public/index.html
    document.addEventListener("DOMContentLoaded", () => {
        console.log("Preview mode - UI structure loaded");
        // Preview-only code here
@@ -330,7 +330,7 @@ Generate **`$PluginPath/Design/v1-test.html`** - **WORKING HTML PREVIEW**:
    **For WebView plugins:** The HTML in `v1-test.html` should be **identical** to what will be in `Source/ui/public/index.html` (minus the preview JavaScript).
 
    **CRITICAL WebView Requirements:**
-   - HTML must use `<script type="module">` for JavaScript imports
+   - ALL JavaScript must be inline in ONE `<script>` block - ES6 modules fail silently in JUCE WebView (webview-008)
    - All element IDs must match parameter IDs from `parameter-spec.md`
    - CSS must be complete and production-ready (embedded in `<style>` tag)
    - HTML structure must match the approved design exactly

--- a/.kilocode/skills/impl/SKILL.md
+++ b/.kilocode/skills/impl/SKILL.md
@@ -55,23 +55,17 @@ Convert the approved design specs into production JUCE WebView code.
 **Create the required directory structure:**
 ```
 $PluginPath/Source/ui/
-â””â”€â”€â”€public/
-    â”‚   index.html          # Production UI based on approved design
-    â”‚
-    â””â”€â”€â”€js/
-        â”‚   index.js        # JUCE integration and parameter binding
-        â”‚
-        â””â”€â”€â”€juce/
-                check_native_interop.js  # Development utility
-                index.js                # JUCE frontend library
+└───public/
+    │   index.html          # Production UI based on approved design - ALL CSS/JS inline (webview-008)
+    │   test-local.html     # Browser-test copy of index.html
 ```
 
 **Implementation Steps:**
-1. **Create directories:** `$PluginPath/Source/ui/public/` and subdirectories
-2. **Copy JUCE frontend library:** Copy `modules/juce_gui_extra/native/javascript/index.js` to `js/juce/index.js`
-3. **Create interop checker:** Generate `js/juce/check_native_interop.js` for development
-4. **Convert design to HTML:** Transform approved design specs into `index.html` with embedded CSS
-5. **Generate JavaScript:** Create `js/index.js` with parameter state setup and UI controls
+1. **Create directory:** `$PluginPath/Source/ui/public/`
+2. **Inline the JUCE frontend library:** Take `_tools/JUCE/modules/juce_gui_extra/native/typescript/webview-interop/dist/index.js`, remove its `import`/`export` statements, expose it as `window.Juce`, and paste it into a single `<script>` block in `index.html` (ES6 modules fail silently in WebView - webview-008)
+3. **Convert design to HTML:** Transform approved design specs into `index.html` with embedded CSS
+4. **Inline UI JavaScript:** Append parameter state setup and UI controls to the SAME `<script>` block - NO external `.js` files
+5. **Create browser-test copy:** Duplicate `index.html` as `test-local.html`
 
 **Conversion Process:**
 - Extract layout, colors, and styling from `v[N]-style-guide.md`
@@ -90,7 +84,7 @@ $PluginPath/Source/ui/
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>[Name] Plugin</title>
-  <script type="module" src="js/index.js"></script>
+  <!-- webview-008: ALL JavaScript must be INLINE - external scripts fail silently -->
   <style>
     /* Styles based on approved v[N]-style-guide.md */
     body {
@@ -112,9 +106,10 @@ $PluginPath/Source/ui/
 </html>
 ```
 
-**ui/public/js/index.js:**
+**Inline JavaScript (inside ui/public/index.html):**
 ```javascript
-import * as Juce from "./juce/index.js";
+// NO imports allowed (webview-008):
+const Juce = window.Juce;
 
 // Initialize parameter states from parameter-spec.md
 const parameterStates = {};
@@ -136,9 +131,7 @@ function initializeUI() {
 âœ… Design converted to WebView code
 
 Files created:
-- $PluginPath/Source/ui/public/index.html
-- $PluginPath/Source/ui/public/js/index.js
-- $PluginPath/Source/ui/public/js/juce/index.js
+- $PluginPath/Source/ui/public/index.html (ALL JavaScript inline)
 
 âš ï¸ **MANDATORY STOP** - You MUST test the WebView setup before proceeding to DSP implementation!
 
@@ -311,7 +304,7 @@ See: `..kilocode/troubleshooting/resolutions/webview-member-order-crash.md`
 1. Review error messages from validation script
 2. Check templates in `templates/webview/`
 3. Compare your code with JUCE example: `_tools/JUCE/examples/Plugins/WebViewPluginDemo.h`
-4. Ensure web files exist: `Source/ui/public/index.html`, `js/index.js`, `js/juce/index.js`
+4. Ensure `Source/ui/public/index.html` exists with ALL JavaScript inline (no separate .js files)
 5. Verify CMakeLists.txt embeds files correctly
 
 **DO NOT PROCEED TO DSP IMPLEMENTATION UNTIL ALL 8 CHECKS PASS**

--- a/.kilocode/skills/skill_design/SKILL.md
+++ b/.kilocode/skills/skill_design/SKILL.md
@@ -280,7 +280,7 @@ Generate **`$PluginPath/Design/v1-test.html`** - **WORKING HTML PREVIEW**:
      <meta charset="UTF-8">
      <meta name="viewport" content="width=device-width, initial-scale=1.0">
      <title>[Name] Plugin</title>
-     <script type="module" src="js/index.js"></script>
+     <!-- webview-008: ALL JavaScript must be INLINE - external scripts fail silently -->
      <style>
        /* Complete CSS based on style guide */
        :root {
@@ -320,7 +320,7 @@ Generate **`$PluginPath/Design/v1-test.html`** - **WORKING HTML PREVIEW**:
 
    **JavaScript placeholder (for preview only):**
    ```javascript
-   // This is a placeholder for preview - actual implementation goes in Source/ui/public/js/index.js
+   // This is a placeholder for preview - actual implementation goes INLINE in Source/ui/public/index.html
    document.addEventListener("DOMContentLoaded", () => {
        console.log("Preview mode - UI structure loaded");
        // Preview-only code here
@@ -330,7 +330,7 @@ Generate **`$PluginPath/Design/v1-test.html`** - **WORKING HTML PREVIEW**:
    **For WebView plugins:** The HTML in `v1-test.html` should be **identical** to what will be in `Source/ui/public/index.html` (minus the preview JavaScript).
 
    **CRITICAL WebView Requirements:**
-   - HTML must use `<script type="module">` for JavaScript imports
+   - ALL JavaScript must be inline in ONE `<script>` block - ES6 modules fail silently in JUCE WebView (webview-008)
    - All element IDs must match parameter IDs from `parameter-spec.md`
    - CSS must be complete and production-ready (embedded in `<style>` tag)
    - HTML structure must match the approved design exactly

--- a/.kilocode/skills/skill_design_webview/SKILL.md
+++ b/.kilocode/skills/skill_design_webview/SKILL.md
@@ -78,6 +78,8 @@ plugins/YourPlugin/
                 â””â”€â”€ index.js
 ```
 
+> **CRITICAL (webview-008):** ES6 modules fail in JUCE WebView - there must be NO separate .js files and no external scripts. Everything goes inline into ONE <script> block in index.html.
+
 ### Step 2: Write index.html
 
 ```html
@@ -86,7 +88,7 @@ plugins/YourPlugin/
 <head>
   <meta charset="UTF-8">
   <title>My Plugin</title>
-  <script type="module" src="js/index.js"></script>
+  <!-- webview-008: ALL JavaScript must be INLINE - external scripts fail silently -->
   <style>
     body {
       margin: 0;
@@ -109,10 +111,12 @@ plugins/YourPlugin/
 </html>
 ```
 
-### Step 3: Write index.js
+### Step 3: Inline JavaScript (inside index.html)
+
+> **CRITICAL (webview-008):** ES6 modules do NOT work in JUCE WebView. Never create separate `.js` files. Inline ALL JavaScript - including the JUCE frontend library exposed as `window.Juce` - in ONE `<script>` block.
 
 ```javascript
-import * as Juce from "./juce/index.js";
+const Juce = window.Juce; // JUCE library INLINED above - never use import/export (webview-008)
 
 document.addEventListener("DOMContentLoaded", () => {
     // Get parameter state from C++
@@ -145,9 +149,7 @@ document.addEventListener("DOMContentLoaded", () => {
 juce_add_binary_data(YourPlugin_WebUI
     SOURCES
         Source/ui/public/index.html
-        Source/ui/public/js/index.js
-        Source/ui/public/js/juce/index.js
-        Source/ui/public/js/juce/check_native_interop.js
+        # NO JS FILES - all JavaScript must be inline in index.html (webview-008)
 )
 
 # Plugin definition
@@ -428,13 +430,13 @@ gainAttachment = std::make_unique<...>(...);  // Too early
 webView = std::make_unique<...>(...);         // Too late
 ```
 
-### âŒ Not Embedding All Files
+### âŒ Embedding Separate JS Files
 ```cmake
-# WRONG - Missing JS files!
+# WRONG - JS files are never loaded (ES6 modules fail - webview-008)!
 juce_add_binary_data(Plugin_WebUI
     SOURCES
         Source/ui/public/index.html
-        # Missing: js files!
+        Source/ui/public/js/index.js   # NOT loaded - must be inlined instead!
 )
 ```
 

--- a/.kilocode/skills/skill_implementation/SKILL.md
+++ b/.kilocode/skills/skill_implementation/SKILL.md
@@ -90,7 +90,7 @@ $PluginPath/Source/ui/
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>[Name] Plugin</title>
-  <script type="module" src="js/index.js"></script>
+  <!-- webview-008: ALL JavaScript must be INLINE - external scripts fail silently -->
   <style>
     /* Styles based on approved v[N]-style-guide.md */
     body {
@@ -114,7 +114,7 @@ $PluginPath/Source/ui/
 
 **ui/public/js/index.js:**
 ```javascript
-import * as Juce from "./juce/index.js";
+const Juce = window.Juce; // JUCE library INLINED above - never use import/export (webview-008)
 
 // Initialize parameter states from parameter-spec.md
 const parameterStates = {};

--- a/.kilocode/troubleshooting/resolutions/webview-blank-screen.md
+++ b/.kilocode/troubleshooting/resolutions/webview-blank-screen.md
@@ -143,7 +143,7 @@ webView->loadHTML(htmlString);  // ❌ Can't load external JS
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <script type="module" src="js/index.js"></script>
+  <!-- webview-008: ALL JavaScript must be INLINE - external scripts fail silently -->
 </head>
 <body>
   <!-- Your UI here -->
@@ -152,17 +152,17 @@ webView->loadHTML(htmlString);  // ❌ Can't load external JS
 ```
 
 **Common issues:**
-- Missing `type="module"` → JavaScript won't load
-- Wrong path to `js/index.js` → File not found
+- Any `<script src="...">` tag → silent failure (webview-008); inline all JS
+- Any `import` statement → fails silently (webview-008)
 - Missing closing tags → HTML parsing fails
 
 ---
 
 ## Step 7: Check JavaScript Initialization
 
-**Verify js/index.js:**
+**Verify inline JavaScript (in index.html):**
 ```javascript
-import * as Juce from "./juce/index.js";
+const Juce = window.Juce; // JUCE library INLINED above - never use import/export (webview-008)
 
 document.addEventListener("DOMContentLoaded", () => {
     console.log("UI initialized");  // Check if this appears in console
@@ -171,8 +171,7 @@ document.addEventListener("DOMContentLoaded", () => {
 ```
 
 **If console shows errors:**
-- Check import path is correct
-- Verify `juce/index.js` exists
+- Look for leftover `import`/`export` statements or `<script src>` tags (webview-008)
 - Check for syntax errors in JavaScript
 
 ---
@@ -229,9 +228,9 @@ Run through this checklist:
 - [ ] WebBrowserComponent uses `.withResourceProvider()`
 - [ ] Uses `getResourceProviderRoot()` not data URI
 - [ ] Parameter relays created BEFORE WebBrowserComponent
-- [ ] Web files exist: `index.html`, `js/index.js`, `js/juce/index.js`
-- [ ] HTML has `<script type="module" src="js/index.js"></script>`
-- [ ] JavaScript imports JUCE library correctly
+- [ ] `index.html` exists with ALL JavaScript inline (no separate .js files)
+- [ ] HTML has NO `<script src="...">` tags and NO import/export statements (webview-008)
+- [ ] Inline `<script>` block defines `window.Juce` before UI code runs
 - [ ] Plugin rebuilt after making changes
 
 ---
@@ -241,7 +240,7 @@ Run through this checklist:
 | Symptom | Solution |
 |---------|----------|
 | Blank screen, no console errors | Check WebView2 runtime installation |
-| Console: "Failed to load module" | Copy JUCE frontend library to `js/juce/index.js` |
+| Console: CORS / module errors | Inline ALL JS into `index.html`, incl. JUCE library (webview-008) |
 | Console: "404 Not Found" | Fix resource provider or verify files embedded |
 | Console: "backend is undefined" | Add `.withNativeIntegrationEnabled()` |
 | Console: "CORS error" | Check resource provider implementation |

--- a/templates/webview/CMakeLists.txt.template
+++ b/templates/webview/CMakeLists.txt.template
@@ -15,8 +15,7 @@ juce_add_plugin({{PLUGIN_NAME_LOWER}}
 juce_add_binary_data({{PLUGIN_NAME_LOWER}}_WebUI
     SOURCES
         Source/ui/public/index.html
-        Source/ui/public/js/index.js
-        Source/ui/public/js/juce/index.js
+    # webview-008: NO JS files - ALL JavaScript must be inline in index.html
     # Add any additional web assets here:
     # Source/ui/public/css/style.css
     # Source/ui/public/assets/logo.png

--- a/templates/webview/README.md
+++ b/templates/webview/README.md
@@ -50,23 +50,21 @@ driveAttachment = std::make_unique<WebSliderParameterAttachment>(...);
 ### 4. Web File Structure
 **Required structure:**
 ```
-Source/ui/public/   (or plugin-root WebUI/)
-├── index.html      (inline CSS/JS preferred — see webview-011)
-├── js/
-│   ├── index.js
-│   └── juce/
-│       └── index.js  (JUCE WebView interop)
+Source/ui/public/
+├── index.html      (ALL CSS/JS inline - REQUIRED, see webview-008)
+└── test-local.html (browser-test copy of index.html)
 ```
+
+**NO separate .js files:** ES6 modules and external scripts fail silently in JUCE WebView (webview-008). Inline everything, including the JUCE interop library (exposed as `window.Juce`).
 
 **JUCE 9 interop (preferred):**
 ```bash
-npm install @juce-framework/webview
-# or copy the drop-in build:
+# Copy the drop-in build, strip its import/export statements,
+# expose it as window.Juce and paste it INSIDE index.html:
 # _tools/JUCE/modules/juce_gui_extra/native/typescript/webview-interop/dist/index.js
-#   -> WebUI/js/juce/index.js
 ```
 
-The old JUCE 8 path `juce_gui_extra/native/javascript/index.js` no longer exists.
+Never reference it as an external file - ES6 modules fail in WebView (webview-008). The old JUCE 8 path `juce_gui_extra/native/javascript/index.js` no longer exists.
 ### 5. Loading Web Content
 **DO:**
 ```cpp


### PR DESCRIPTION
## Problem

Found while developing a WebView plugin: an agent following the impl/design skills produced a broken UI. The repo contradicts itself:

- `troubleshooting/resolutions/webview-es6-modules-fail.md` (**webview-008**, Critical, SOLVED) documents that **ES6 modules fail silently** in JUCE WebView — knobs render as dots, no JS executes
- But multiple skills, troubleshooting resolutions, and templates still actively instruct the broken pattern:
  - `<script type="module" src="js/index.js"></script>`
  - `import * as Juce from "./juce/index.js"`
  - CMake embedding separate `.js` files

## Fix

Aligned **22 files** across all agent config trees (`.claude/`, `.agent/`, `.kilocode/`) with the documented webview-008 solution:

- **All JavaScript must be inline** in a single `<script>` block in `Source/ui/public/index.html` — including the JUCE frontend interop library, pasted from `_tools/JUCE/.../webview-interop/dist/index.js` with its `import`/`export` statements removed and exposed as `window.Juce`
- **CMake embeds only `index.html`** via `juce_add_binary_data` (no JS files)
- `test-local.html` is a browser-test copy of `index.html`

### Files updated
- `skills/impl/SKILL.md` + `skills/skill_implementation/SKILL.md` — directory tree, steps (also replaced the stale JUCE 8 copy path `native/javascript/index.js`), examples, validation checklists
- `skills/design/SKILL.md` + `skills/skill_design/SKILL.md` — required HTML structure, "must use type=module" requirement inverted
- `skills/skill_design_webview/SKILL.md` (+ `SKILL_OLD.md`) — Step 2/3 examples, CMake block, "Not Embedding All Files" mistake section corrected
- `troubleshooting/resolutions/webview-blank-screen.md` — Steps 6-7, diagnostic checklist and solutions table (previously *required* `type="module"`)
- `rules/juce-build-protocols.md` section 2A — previously said to load `js/juce/index.js` externally
- `templates/webview/README.md` + `CMakeLists.txt.template` — file structure and binary-data sources

Remaining `type="module"` mentions are only intentional ❌ failing-example snippets in the known-issues documentation itself.

## Testing
- Verified against the authoritative `webview-es6-modules-fail.md` resolution and the CloudWash reference (978-line all-inline `index.html`)
- Grep audit confirms no instructional module/import patterns remain in any skill, rule, resolution, or template